### PR TITLE
サインアップ・サインイン機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,10 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# Slim install
+# 追加でインストール
 gem 'slim-rails'
 gem 'html2slim'
 
-# Devise install
 gem 'devise'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -234,6 +237,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.2)
+  rails-i18n
   sass-rails (>= 6)
   selenium-webdriver
   slim-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :user_name]) 
+  end
+
+  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    static_pages_home_path
+  end
+
+
+  # deviseのストロングパラメーターを編集
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :user_name]) 
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   # deviseのストロングパラメーターを編集
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :user_name]) 
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i(name user_name)) 
   end
 
   

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,12 +51,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    static_pages_home_path
+  end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    static_pages_home_path
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,2 @@
-@import "~bootstrap/scss/bootstrap";
+@import '~bootstrap/scss/bootstrap';
+@import './custom.scss';

--- a/app/javascript/stylesheets/custom.scss
+++ b/app/javascript/stylesheets/custom.scss
@@ -1,0 +1,36 @@
+// ナビバー
+
+a.home-btn {
+  color: black
+}
+
+// sign_up, sign_in
+
+.sign-wrapper {
+  padding: 1rem 0 100%;
+  background-color: rgba(236, 236, 236, 0.671);
+}
+
+.sign-container {
+  width: 50%;
+  margin: 0 auto;
+  padding: 1rem 0 1rem 5rem;
+  background-color: white;
+}
+
+.field {
+  margin-bottom: 1rem;
+  input {
+    width: 400px;
+  }
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  .btn {
+    position: relative;
+    border-radius: 50px;
+    margin-right: 1rem;
+  }
+}

--- a/app/javascript/stylesheets/custom.scss
+++ b/app/javascript/stylesheets/custom.scss
@@ -34,3 +34,7 @@ a.home-btn {
     margin-right: 1rem;
   }
 }
+
+#error_explanation {
+  color: red;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :user_name, presence: true, uniqueness: true, length: { maximum: 15 }
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,3 +1,4 @@
 header
   .navbar
-    = link_to "ホーム", '#'
+    .container
+      = link_to "ホーム", '#', class: "home-btn"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,4 +1,4 @@
 header
   .navbar
     .container
-      = link_to "ホーム", '#', class: "home-btn"
+      = link_to "ホーム", static_pages_home_url, class: "home-btn"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,0 +1,3 @@
+header
+  .navbar
+    = link_to "ホーム", '#'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,4 +9,5 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
+    = render 'layouts/header'
     = yield

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -2,7 +2,7 @@
   .sign-container
     h2
       | アカウントを作成
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+    = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
       = render "devise/shared/error_messages", resource: resource
       .field
         = f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "名前"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,17 +1,19 @@
-h2
-  | アカウントを作成
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "名前"
-  .field
-    = f.text_field :user_name, autocomplete: "user_name", placeholder: "ユーザー名"
-  .field
-    = f.email_field :email, autocomplete: "email", placeholder: "メールアドレス"
-  .field
-    = f.password_field :password, autocomplete: "new-password", placeholder: "パスワード"
-  .field
-    = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを確認"
-  .actions
-    = f.submit "登録する"
-= render "users/shared/links"
+.sign-wrapper
+  .sign-container
+    h2
+      | アカウントを作成
+    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        = f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "名前"
+      .field
+        = f.text_field :user_name, autocomplete: "user_name", placeholder: "ユーザー名"
+      .field
+        = f.email_field :email, autocomplete: "email", placeholder: "メールアドレス"
+      .field
+        = f.password_field :password, autocomplete: "new-password", placeholder: "パスワード"
+      .field
+        = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを確認"
+      .actions
+        = f.submit "登録する", class: "btn btn-primary"
+        = render "users/shared/links"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,24 +1,17 @@
 h2
-  | Sign up
+  | アカウントを作成
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "名前"
   .field
-    = f.label :password
-    - if @minimum_password_length
-      em
-        | (
-        = @minimum_password_length
-        |  characters minimum)
-    br
-    = f.password_field :password, autocomplete: "new-password"
+    = f.text_field :user_name, autocomplete: "user_name", placeholder: "ユーザー名"
   .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: "new-password"
+    = f.email_field :email, autocomplete: "email", placeholder: "メールアドレス"
+  .field
+    = f.password_field :password, autocomplete: "new-password", placeholder: "パスワード"
+  .field
+    = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを確認"
   .actions
-    = f.submit "Sign up"
+    = f.submit "登録する"
 = render "users/shared/links"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -1,10 +1,12 @@
-h2
-  | Tweet Appにログイン
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス"
-  .field
-    = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード"
-  .actions
-    = f.submit "ログイン"
-= render "users/shared/links"
+.sign-wrapper
+  .sign-container
+    h2
+      | Tweet Appにログイン
+    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      .field
+        = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス"
+      .field
+        = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード"
+      .actions
+        = f.submit "ログイン", class: "btn btn-primary"
+        = render "users/shared/links"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -1,18 +1,10 @@
 h2
-  | Log in
+  | Tweet Appにログイン
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス"
   .field
-    = f.label :password
-    br
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
+    = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード"
   .actions
-    = f.submit "Log in"
+    = f.submit "ログイン"
 = render "users/shared/links"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -1,12 +1,12 @@
 .sign-wrapper
   .sign-container
     h2
-      | Tweet Appにログイン
-    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      | Tweet Appにサインイン
+    = form_with model: @user, url: user_session_path, id: 'new_user', class: 'new_user', local: true do |f|
       .field
         = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス"
       .field
         = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード"
       .actions
-        = f.submit "ログイン", class: "btn btn-primary"
+        = f.submit "サインイン", class: "btn btn-primary"
         = render "users/shared/links"

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -1,19 +1,4 @@
 - if controller_name != 'sessions'
-  = link_to "ログインはこちら", new_session_path(resource_name)
-  br
+  = link_to "サインインはこちら", new_session_path(resource_name)
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "アカウント作成はこちら", new_registration_path(resource_name)
-  br
-/ - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-/   = link_to "Forgot your password?", new_password_path(resource_name)
-/   br
-/ - if devise_mapping.confirmable? && controller_name != 'confirmations'
-/   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
-/   br
-/ - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-/   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-/   br
-/ - if devise_mapping.omniauthable?
-/   - resource_class.omniauth_providers.each do |provider|
-/     = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
-/     br

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -2,18 +2,18 @@
   = link_to "ログインはこちら", new_session_path(resource_name)
   br
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "アカウント作成はこちら", new_registration_path(resource_name)
   br
-- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
-  br
-- if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
-  br
-- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
-  br
-- if devise_mapping.omniauthable?
-  - resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
-    br
+/ - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+/   = link_to "Forgot your password?", new_password_path(resource_name)
+/   br
+/ - if devise_mapping.confirmable? && controller_name != 'confirmations'
+/   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+/   br
+/ - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+/   = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+/   br
+/ - if devise_mapping.omniauthable?
+/   - resource_class.omniauth_providers.each do |provider|
+/     = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+/     br

--- a/app/views/users/shared/_links.html.slim
+++ b/app/views/users/shared/_links.html.slim
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  = link_to "ログインはこちら", new_session_path(resource_name)
   br
 - if devise_mapping.registerable? && controller_name != 'registrations'
   = link_to "Sign up", new_registration_path(resource_name)

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,8 @@ module TweetApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.generators.template_engine = :slim 
+    config.generators.template_engine = :slim
+    config.i18n.default_locale = :ja
 
     config.generators do |g|
       g.stylesheets false

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,95 @@
+ja:
+  errors:
+    messages:
+      expired: "有効期限切れです。新規登録してください"
+      not_found: "は見つかりませんでした"
+      already_confirmed: "は既に登録済みです。サインインしてください"
+      not_locked: "ロックされていません"
+      not_saved:
+        one: "エラーにより、この %{resource} を保存できません"
+        other: "%{count} 個のエラーにより、この %{resource} を保存できません"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        user_name: ユーザー名
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にサインイン"
+    models:
+      user: "ユーザー"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "サインイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "サインイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "サインイン"
+        sign_in_with_provider: "%{provider}でサインイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: "users/sessions",
+  }
   get 'static_pages/home'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,12 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
     sessions: "users/sessions",
   }
+
+  devise_scope :user do
+    get "signup", :to => "users/registrations#new"
+    get "login", :to => "users/sessions#new"
+    get "logout", :to => "users/sessions#destroy"
+  end
+
   get 'static_pages/home'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     get "signup", :to => "users/registrations#new"
-    get "login", :to => "users/sessions#new"
-    get "logout", :to => "users/sessions#destroy"
+    get "signin", :to => "users/sessions#new"
+    get "signout", :to => "users/sessions#destroy"
   end
 
   get 'static_pages/home'

--- a/db/migrate/20200210142133_add_name_and_user_name_to_users.rb
+++ b/db/migrate/20200210142133_add_name_and_user_name_to_users.rb
@@ -1,0 +1,7 @@
+class AddNameAndUserNameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :name, :string, null: false
+    add_column :users, :user_name, :string, null: false
+    add_index :users, :user_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_08_113232) do
+ActiveRecord::Schema.define(version: 2020_02_10_142133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,11 @@ ActiveRecord::Schema.define(version: 2020_02_08_113232) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.string "user_name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["user_name"], name: "index_users_on_user_name", unique: true
   end
 
 end


### PR DESCRIPTION
## issue番号
#8 

## 背景
サインアップ・サインインができるようにしたい。

サインアップする際の必要な情報は以下の4つ

+ 名前
+ ユーザーネーム（Twitterでいう@から始まるユーザーネーム）
+ メールアドレス
+ パスワード
+ パスワードの確認

サインインする際の必要な情報

+ メールアドレス
+ パスワード


## 確認項目
+ サインアップ機能
  + 以下の情報を入力してサインアップすることができる
    + 名前
    + ユーザーネーム
    + メールアドレス
    + パスワード
    + パスワードの確認
  + バリデーション
    + 名前は1文字以上~50文字以下
    + ユーザーネームは1文字以上~15文字以下
    + ユーザーネームはユニークである
  + サインアップすると仮のホーム(トップ)ページに遷移する
  + サインアップ画面にサインイン画面に遷移するリンクがある
+ サインイン機能
  + 以下の情報を入力してサインインすることができる
    + メールアドレス
    + パスワード
  + サインイン画面にサインアップ画面に遷移するリンクがある

![画面収録 2020-02-11 23 24 09 mov](https://user-images.githubusercontent.com/54460011/74245191-f81cff00-4d25-11ea-8797-5e7ea6b75bc1.gif)

## 参考記事
【Rails】deviseを導入してみる
https://qiita.com/Hal_mai/items/350c400e8763ce0487a3
[初心者] deviseを使ってログイン機能を実装してみよう
https://qiita.com/Orangina1050/items/a16e655519a60f35b394